### PR TITLE
Fixed some edpc shapes.

### DIFF
--- a/shapes/edpc/and.shape
+++ b/shapes/edpc/and.shape
@@ -12,6 +12,6 @@
   <aspectratio type="fixed"/>
   <svg:svg>
     <svg:ellipse style="fill: default;" cx="1" cy="1" rx="1" ry="1"/>
-    <svg:polygon style="fill: default;" points="0.3,1.5 0.4,1.5 1,0.7 1.6,1.5 1.7,1.5 1,0.5 "/>
+    <svg:polygon style="fill: foreground;" points="0.3,1.5 0.4,1.5 1,0.7 1.6,1.5 1.7,1.5 1,0.5 "/>
   </svg:svg>
 </shape>

--- a/shapes/edpc/or.shape
+++ b/shapes/edpc/or.shape
@@ -12,6 +12,6 @@
   <aspectratio type="fixed"/>
   <svg:svg>
     <svg:ellipse style="fill: default" cx="10" cy="12" rx="2" ry="2"/>
-    <svg:polygon style="fill: default" points="8.6,11 8.8,11 10,13 11.2,11 11.4,11 10,13.4 "/>
+    <svg:polygon style="fill: foreground" points="8.6,11 8.8,11 10,13 11.2,11 11.4,11 10,13.4 "/>
   </svg:svg>
 </shape>

--- a/shapes/edpc/xor.shape
+++ b/shapes/edpc/xor.shape
@@ -12,6 +12,6 @@
   <aspectratio type="fixed"/>
   <svg:svg>
     <svg:ellipse style="fill: default;" cx="1" cy="1" rx="1" ry="1"/>
-    <svg:text style="fill: default; stroke: default; text-color: default; font-size: 1.0; text-anchor:middle; font-family: sans; font-style: normal; font-weight: 700" x="1" y="1.2" textLength="1.26">XOR</svg:text>
+    <svg:text style="fill: foreground; stroke: foreground; text-color: foreground; font-size: 1.0; text-anchor:middle; font-family: sans; font-style: normal; font-weight: 700" x="1" y="1.3" textLength="1.26">XOR</svg:text>
   </svg:svg>
 </shape>


### PR DESCRIPTION
The "and" and "or" symbols' polygons are now filled with the foreground color.

The text of the "xor" symbol had the background color before, which was wrong. It now has the foreground color. Also the "xor" text is now placed a little more central.